### PR TITLE
Add initial support for wasm-wasi builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on:
+  push:
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -24,24 +24,24 @@ jobs:
         run: brew install cmake
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests (without HF feature)
-        run: cargo test --verbose
+        run: cargo test --locked --verbose
 
       - name: Run tests (with HF feature)
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: cargo test --features hf --verbose
+        run: cargo test --locked --features hf --verbose
 
       - name: Build documentation
-        run: cargo doc --no-deps --features hf
+        run: cargo doc --locked --no-deps --features hf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,39 +9,103 @@ env:
 
 jobs:
   test:
-    name: Test on macOS
-    runs-on: macos-latest
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO: test wasi builds on MacOS, too
+        os: [ubuntu-latest]
+        # TODO: add wasm32-wasip1-threads when supported
+        target: [native, wasm32-wasip1, wasm32-wasip2]
+        include:
+          - os: macos-latest
+            target: native
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: recursive
 
+      - name: Ensure wasi-sdk has tags
+        if: startsWith(matrix.target, 'wasm32-wasi')
+        run: |
+          # We need tags for `git describe` to work in wasi-sdk build.
+          # `actions/checkout` does not handle this very well.
+          # The `--depth 1` works fine as long as the wasi-sdk submodule is at a tagged commit.
+          cd build/wasi-sdk/
+          git fetch --tags --depth 1
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1,wasm32-wasip1-threads,wasm32-wasip2
 
       - name: Install CMake
+        if: startsWith(matrix.os, 'macos-')
         run: brew install cmake
+
+      - name: Install llvm clang with wasm support
+        if: startsWith(matrix.os, 'ubuntu-')
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x ./llvm.sh
+          sudo ./llvm.sh
+          sudo apt install libclang-rt-22-dev-wasm32
+
+          # The following snippet fixes what seems to be a Ubuntu/LLVM packaging bug:
+          # `wasm-ld` is looking for libclang_rt under a different name.
+          for target in wasm32-unknown-wasi{p1,p1-threads,p2}; do
+            sudo mkdir -p /usr/lib/llvm-22/lib/clang/22/lib/"$target"/
+            sudo ln -s ../wasi/libclang_rt.builtins-wasm32.a /usr/lib/llvm-22/lib/clang/22/lib/"$target"/libclang_rt.builtins.a
+          done
+
+          echo CC=clang-22 >> "$GITHUB_ENV"
+          echo CXX=clang++-22 >> "$GITHUB_ENV"
+
+      - name: Install wasm-component-ld
+        if: startsWith(matrix.target, 'wasm32')
+        run: |
+          cargo install wasm-component-ld
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Cache cargo registry
         uses: actions/cache@v5
         with:
           path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}_${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v5
         with:
           path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}_${{ matrix.target }}-cargo-git-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run tests (without HF feature)
+        if: matrix.target == 'native'
         run: cargo test --locked --verbose
 
       - name: Run tests (with HF feature)
+        if: matrix.target == 'native'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: cargo test --locked --features hf --verbose
 
       - name: Build documentation
+        if: matrix.target == 'native'
         run: cargo doc --locked --no-deps --features hf
+
+      - name: Build for ${{ matrix.target }}
+        if: matrix.target != 'native'
+        run: |
+          export RUST_BACKTRACE=1
+          # The wasi-sdk sometimes fails spuriously with a No such file or directory
+          # at cmake/wasi-wits.cmake (seems to only happen in CI).
+          # Thus, retry the build once if it fails.
+          BUILD="cargo build --locked --target ${{ matrix.target }}"
+          if $BUILD; then
+            echo Succeeded on the first attempt
+          else
+            $BUILD && echo Succeeded on the second attempt
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           # The wasi-sdk sometimes fails spuriously with a No such file or directory
           # at cmake/wasi-wits.cmake (seems to only happen in CI).
           # Thus, retry the build once if it fails.
-          BUILD="cargo build --locked --target ${{ matrix.target }}"
+          BUILD="cargo build --locked --all-features --target ${{ matrix.target }}"
           if $BUILD; then
             echo Succeeded on the first attempt
           else

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "xgrammar"]
 	path = xgrammar
 	url = https://github.com/mlc-ai/xgrammar.git
+[submodule "build/wasi-sdk"]
+	path = build/wasi-sdk
+	url = https://github.com/WebAssembly/wasi-sdk.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -1903,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -2587,6 +2587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,6 +2847,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 name = "xgrammar-rs"
 version = "0.2.2"
 dependencies = [
+ "cc",
  "cmake",
  "cxx",
  "cxx-build",
@@ -2848,6 +2858,7 @@ dependencies = [
  "serial_test",
  "tokenizers",
  "walkdir",
+ "which",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,8 +542,16 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "cc",
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1266,28 +1289,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "onig"
-version = "6.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
-dependencies = [
- "bitflags",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "openssl"
@@ -2129,13 +2130,12 @@ dependencies = [
  "dary_heap",
  "derive_builder",
  "esaxx-rs",
+ "fancy-regex",
  "getrandom 0.3.4",
- "indicatif",
  "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
- "onig",
  "paste",
  "rand",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ name = "xgrammar"
 [dependencies]
 # cxx = { version = "1", path = "../cxx", features = ["compile-builtins-at-bridge-stage"] }
 cxx = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master" }
+tokenizers = { version = "0.22", optional = true }
 serde_json = "1.0"
 
 [build-dependencies]
@@ -28,6 +29,7 @@ cmake = "0.1"
 cxx-build = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master" }
 
 [dev-dependencies]
+hf-hub = { version = "0.5" }
 schemars = "1.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -36,12 +38,4 @@ serial_test = "3.4"
 [features]
 default = []
 tokenizers = ["dep:tokenizers"]
-hf = ["tokenizers", "dep:hf-hub"]
-
-[dependencies.tokenizers]
-version = "0.22"
-optional = true
-
-[dependencies.hf-hub]
-version = "0.5"
-optional = true
+hf = ["tokenizers"] # `hf` only remains for compatibility, it is synonymous to `tokenizers`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xgrammar-rs"
 version = "0.2.2"
 edition = "2024"
+rust-version = "1.85.1"
 build = "build.rs"
 links = "xgrammar"
 authors = ["Eugene Bokhan <eugenebokhan@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ name = "xgrammar"
 
 [dependencies]
 cxx = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master", features = ["compile-builtins-at-bridge-stage"] }
-tokenizers = { version = "0.22", optional = true }
+tokenizers = { version = "0.22", features = ["fancy-regex"], default-features = false, optional = true }
 serde_json = "1.0"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,15 +19,16 @@ categories = ["parsing", "text-processing"]
 name = "xgrammar"
 
 [dependencies]
-# cxx = { version = "1", path = "../cxx", features = ["compile-builtins-at-bridge-stage"] }
-cxx = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master" }
+cxx = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master", features = ["compile-builtins-at-bridge-stage"] }
 tokenizers = { version = "0.22", optional = true }
 serde_json = "1.0"
 
 [build-dependencies]
-walkdir = "2.5"
+cc = "1.2.62"
 cmake = "0.1"
 cxx-build = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master" }
+walkdir = "2.5"
+which = "8"
 
 [dev-dependencies]
 hf-hub = { version = "0.5" }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For HuggingFace tokenizer support:
 
 ```toml
 [dependencies]
-xgrammar-rs = { version = "0.1", features = ["hf"] } 
+xgrammar-rs = { version = "0.1", features = ["tokenizers"] }
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -145,6 +145,27 @@ assert!(matcher.is_terminated());
 
 For detailed API documentation, visit [docs.rs/xgrammar-rs](https://docs.rs/xgrammar-rs).
 
+## WebAssembly support
+
+The library supports Rust's wasm32-wasi* targets. When compiling for wasi targets,
+a wasi sysroot is required, and the default build process of xgrammar-rs will compile
+[wasi-sdk](https://github.com/WebAssembly/wasi-sdk) and use it as a WASI sysroot.
+This requires that the system system has:
+- clang compiler version 22 or newer, supporting the target the corresponding wasi target
+  (including the "compiler runtime libraries for clang" for WASI, aka wasi-compiler-rt);
+- [wasm-component-ld](https://github.com/bytecodealliance/wasm-component-ld).
+
+Building the sysroot might take a while.
+
+The user may also choose to provide their own wasi sysroot. If the `WASI_SYSROOT`
+environment variable is set, xgrammar-rs will skip the wasi-sdk building stage
+and use the provided sysroot. Note that the provided sysroot must be compiled with
+C++ exceptions support. For details, refer to wasi-sdk's README or your sysroot
+provider documentation.
+
+Note: as of now, the `tokenizers` feature is only supported when `WASI_SYSROOT`
+is provided by the user.
+
 ## License
 
 This project is licensed under the Apache License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -157,14 +157,11 @@ This requires that the system system has:
 
 Building the sysroot might take a while.
 
-The user may also choose to provide their own wasi sysroot. If the `WASI_SYSROOT`
-environment variable is set, xgrammar-rs will skip the wasi-sdk building stage
-and use the provided sysroot. Note that the provided sysroot must be compiled with
-C++ exceptions support. For details, refer to wasi-sdk's README or your sysroot
-provider documentation.
-
-Note: as of now, the `tokenizers` feature is only supported when `WASI_SYSROOT`
-is provided by the user.
+The user may also choose to provide their own wasi sysroot (advanced).
+If the `WASI_SYSROOT` environment variable is set, xgrammar-rs will skip
+the wasi-sdk building stage and use the provided sysroot. Note that the provided
+sysroot must be compiled with C++ exceptions support. For details, refer to
+wasi-sdk's README or your sysroot provider documentation.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,8 @@
 mod build;
 
 fn main() {
-    println!("cargo:rerun-if-changed=src/cxx_utils.hpp");
-    println!("cargo:rerun-if-changed=src/cxx_utils/");
+    println!("cargo::rerun-if-changed=src/cxx_utils.hpp");
+    println!("cargo::rerun-if-changed=src/cxx_utils/");
 
     #[cfg(target_os = "windows")]
     build::windows::configure_libclang();
@@ -29,7 +29,7 @@ fn main() {
 
     if build::common::is_truthy_env("XGRAMMAR_RS_DEBUG_INCLUDES") {
         println!(
-            "cargo:warning=xgrammar-rs: extra_clang_args={}",
+            "cargo::warning=xgrammar-rs: extra_clang_args={}",
             extra_clang_args.join(" "),
         );
     }

--- a/build.rs
+++ b/build.rs
@@ -1,27 +1,47 @@
+use std::env;
+
 #[path = "build/mod.rs"]
 mod build;
 
 fn main() {
     println!("cargo::rerun-if-changed=src/cxx_utils.hpp");
     println!("cargo::rerun-if-changed=src/cxx_utils/");
+    println!("cargo::rerun-if-env-changed=WASI_SYSROOT");
+
+    let target = env::var("TARGET").expect("cargo shall set TARGET");
 
     #[cfg(target_os = "windows")]
     build::windows::configure_libclang();
     let ctx = build::submodules::collect_build_context();
-    let destination_path = build::cmake::build_xgrammar_cmake(&ctx);
-    build::cmake::link_xgrammar_static(&ctx, &destination_path);
+
+    let mut wasm_c_cxx_flags = vec![];
+    if target.starts_with("wasm32-wasi") {
+        build::wasi_sysroot::find_or_build_and_set();
+        // Flags for C++ exceptions to work correctly with wasi-sdk:
+        // https://github.com/WebAssembly/wasi-sdk/blob/3a57aa06289ee679a62119d8842ca9ee7a4e5ee9/CppExceptions.md#compiling-code-with-c-exceptions
+        // The set of flags may change for future wasi-sdk releases.
+        println!("cargo::rustc-link-arg=-fwasm-exceptions");
+        println!("cargo::rustc-link-lib=static=unwind");
+        wasm_c_cxx_flags =
+            vec!["-fwasm-exceptions", "-mllvm", "-wasm-use-legacy-eh=false"];
+    }
+
+    let destination_path =
+        build::xgrammar_cmake::build_xgrammar_cmake(&ctx, &wasm_c_cxx_flags);
+    build::xgrammar_cmake::link_xgrammar_static(&ctx, &destination_path);
 
     let mut bridge_builder = cxx_build::bridge("src/lib.rs");
 
-    let mut extra_clang_args = vec!["-std=c++17".to_string()];
-    if !std::env::var("TARGET").expect("TARGET is unset").starts_with("wasm32-")
-    {
+    let mut extra_compiler_flags = vec!["-std=c++17".to_string()];
+    if !target.starts_with("wasm32-") {
         #[cfg(target_os = "windows")]
-        extra_clang_args.extend(build::windows::target_clang_args(&ctx.target));
+        extra_compiler_flags
+            .extend(build::windows::target_clang_args(&ctx.target));
         #[cfg(target_os = "macos")]
-        extra_clang_args.extend(build::macos::target_clang_args(&ctx.target));
+        extra_compiler_flags
+            .extend(build::macos::target_clang_args(&ctx.target));
         #[cfg(target_os = "linux")]
-        extra_clang_args.extend(build::linux::clang_include_args(
+        extra_compiler_flags.extend(build::linux::clang_include_args(
             &ctx.target,
             bridge_builder.get_compiler().path(),
         ));
@@ -29,8 +49,12 @@ fn main() {
 
     if build::common::is_truthy_env("XGRAMMAR_RS_DEBUG_INCLUDES") {
         println!(
-            "cargo::warning=xgrammar-rs: extra_clang_args={}",
-            extra_clang_args.join(" "),
+            "cargo::warning=xgrammar-rs: extra_compiler_flags={}",
+            extra_compiler_flags.join(" "),
+        );
+        println!(
+            "cargo::warning=xgrammar-rs: wasm_c_cxx_flags={}",
+            wasm_c_cxx_flags.join(" "),
         );
     }
 
@@ -41,6 +65,7 @@ fn main() {
         .include(ctx.dlpack_include_dir)
         .include(ctx.picojson_include_dir)
         .include(ctx.manifest_dir)
-        .flags(extra_clang_args);
+        .flags(wasm_c_cxx_flags)
+        .flags(extra_compiler_flags);
     bridge_builder.compile("cxxbridge");
 }

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,8 @@
 mod build;
 
 fn main() {
-    println!("carg:rerun-if-changed=src/cxx_utils.hpp");
-    println!("carg:rerun-if-changed=src/cxx_utils/");
+    println!("cargo:rerun-if-changed=src/cxx_utils.hpp");
+    println!("cargo:rerun-if-changed=src/cxx_utils/");
 
     #[cfg(target_os = "windows")]
     build::windows::configure_libclang();
@@ -29,7 +29,7 @@ fn main() {
 
     if build::common::is_truthy_env("XGRAMMAR_RS_DEBUG_INCLUDES") {
         println!(
-            "carg:warning=xgrammar-rs: extra_clang_args={}",
+            "cargo:warning=xgrammar-rs: extra_clang_args={}",
             extra_clang_args.join(" "),
         );
     }

--- a/build/cmake.rs
+++ b/build/cmake.rs
@@ -81,19 +81,20 @@ pub fn build_xgrammar_cmake(ctx: &BuildContext) -> PathBuf {
         cmake_config.cxxflag("/EHsc");
     }
 
-    let build_profile =
-        match env::var("PROFILE").unwrap_or_else(|_| "release".into()).as_str()
-        {
-            "debug" => "Debug",
-            "release" => "Release",
-            other => {
-                eprintln!(
-                    "Unknown cargo PROFILE '{}' -> using RelWithDebInfo",
-                    other
-                );
-                "RelWithDebInfo"
-            },
-        };
+    let build_profile = match env::var("PROFILE")
+        .unwrap_or_else(|_| "release".into())
+        .as_str()
+    {
+        "debug" => "Debug",
+        "release" => "Release",
+        other => {
+            println!(
+                "cargo:warning=Unknown cargo PROFILE '{}' -> using RelWithDebInfo",
+                other
+            );
+            "RelWithDebInfo"
+        },
+    };
     cmake_config.profile(build_profile);
 
     if !ctx.target.is_empty() {

--- a/build/cmake.rs
+++ b/build/cmake.rs
@@ -89,7 +89,7 @@ pub fn build_xgrammar_cmake(ctx: &BuildContext) -> PathBuf {
         "release" => "Release",
         other => {
             println!(
-                "cargo:warning=Unknown cargo PROFILE '{}' -> using RelWithDebInfo",
+                "cargo::warning=Unknown cargo PROFILE '{}' -> using RelWithDebInfo",
                 other
             );
             "RelWithDebInfo"
@@ -152,6 +152,6 @@ pub fn link_xgrammar_static(
     let lib_search_dir = find_xgrammar_lib_dir(&cmake_build_dir)
         .or_else(|| find_xgrammar_lib_dir(destination_path))
         .unwrap_or_else(|| destination_path.join("lib"));
-    println!("cargo:rustc-link-search=native={}", lib_search_dir.display());
-    println!("cargo:rustc-link-lib=static=xgrammar");
+    println!("cargo::rustc-link-search=native={}", lib_search_dir.display());
+    println!("cargo::rustc-link-lib=static=xgrammar");
 }

--- a/build/mod.rs
+++ b/build/mod.rs
@@ -1,6 +1,7 @@
-pub mod cmake;
 pub mod common;
 pub mod submodules;
+pub mod wasi_sysroot;
+pub mod xgrammar_cmake;
 
 #[cfg(target_os = "windows")]
 pub mod windows;

--- a/build/submodules.rs
+++ b/build/submodules.rs
@@ -45,7 +45,7 @@ pub fn ensure_xgrammar_source_tree(manifest_dir: &Path) -> PathBuf {
 }
 
 pub fn collect_build_context() -> BuildContext {
-    println!("cargo:rerun-if-env-changed=XGRAMMAR_SRC_DIR");
+    println!("cargo::rerun-if-env-changed=XGRAMMAR_SRC_DIR");
 
     let manifest_dir = abs_path(
         env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"),
@@ -53,23 +53,23 @@ pub fn collect_build_context() -> BuildContext {
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
 
     println!(
-        "cargo:rerun-if-changed={}",
+        "cargo::rerun-if-changed={}",
         manifest_dir.join(".gitmodules").display()
     );
 
     let xgrammar_src_dir = ensure_xgrammar_source_tree(&manifest_dir);
     println!(
-        "cargo:rerun-if-changed={}",
+        "cargo::rerun-if-changed={}",
         xgrammar_src_dir.join("include").display()
     );
-    println!("cargo:rerun-if-changed={}/cpp", xgrammar_src_dir.display());
-    println!("cargo:rerun-if-changed={}/3rdparty", xgrammar_src_dir.display());
+    println!("cargo::rerun-if-changed={}/cpp", xgrammar_src_dir.display());
+    println!("cargo::rerun-if-changed={}/3rdparty", xgrammar_src_dir.display());
     println!(
-        "cargo:rerun-if-changed={}",
+        "cargo::rerun-if-changed={}",
         xgrammar_src_dir.join("CMakeLists.txt").display()
     );
     println!(
-        "cargo:rerun-if-changed={}",
+        "cargo::rerun-if-changed={}",
         xgrammar_src_dir.join(".gitmodules").display()
     );
 

--- a/build/wasi_sysroot.rs
+++ b/build/wasi_sysroot.rs
@@ -1,0 +1,109 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use cmake::Config as CMakeConfig;
+use which::which;
+
+pub fn find_or_build_and_set() {
+    let wasi_sdk_path = "build/wasi-sdk";
+
+    if env::var("WASI_SYSROOT").is_err() {
+        let built_wasi_sdk = build_wasi_sdk(&wasi_sdk_path);
+        // Note: the `build/` prefix in the path below is created by the `cmake` crate (hardcoded, as of this writing)
+        let wasi_sysroot_path =
+            built_wasi_sdk.join("build/install/share/wasi-sysroot/");
+        // Note: need to set this as an environment variable, since `cc-rs` does not provide a method
+        // for specifying wasi sysroot location, and only checks an environment variable.
+        // SAFETY: The function is safe in single-threaded programs (like this build script)
+        unsafe { env::set_var("WASI_SYSROOT", &wasi_sysroot_path) };
+    }
+}
+
+static NEED_CLANG_LIKE_COMPILER_ERR_MSG: &str =
+    "Wasi-sdk requires clang-like C and C++ compilers, but:";
+
+fn wasi_c_compiler_cfg() -> Option<cc::Build> {
+    let mut c_build_config = cc::Build::new();
+    c_build_config.cpp(false);
+    let default_c_compiler = c_build_config.get_compiler();
+    if default_c_compiler.is_like_clang() {
+        // Need to set the compiler to itself 🤪
+        // That's because we want to fix this compiler (which we know is clang-like).
+        // Otherwise `cc` may decide to change it later
+        c_build_config.compiler(c_build_config.get_compiler().path());
+    } else {
+        println!("cargo::warning=C: not like clang");
+        println!("cargo::warning={NEED_CLANG_LIKE_COMPILER_ERR_MSG}");
+        println!(
+            "cargo::warning=C compiler at {:?} is not clang-like (you may set the `CC` environment variable to the path to your C compiler)",
+            default_c_compiler.path()
+        );
+        let Ok(path_to_clang) = which("clang") else {
+            println!("cargo::error=Could not find `clang` on the system");
+            return None;
+        };
+        println!("cargo::warning=Using {:?} as a C compiler", path_to_clang);
+        c_build_config.compiler(path_to_clang);
+    }
+    Some(c_build_config)
+}
+
+fn wasi_cpp_compiler_cfg() -> Option<cc::Build> {
+    let mut cpp_build_config = cc::Build::new();
+    cpp_build_config.cpp(true);
+    let default_cpp_compiler = cpp_build_config.get_compiler();
+    if default_cpp_compiler.is_like_clang() {
+        // Need to set the compiler to itself 🤪
+        // That's because we want to fix this compiler (which we know is clang-like).
+        // Otherwise `cc` may decide to change it later
+        cpp_build_config.compiler(cpp_build_config.get_compiler().path());
+    } else {
+        println!("cargo::warning={NEED_CLANG_LIKE_COMPILER_ERR_MSG}");
+        println!(
+            "cargo::warning=C++ compiler {:?} is not clang-like (you may set the `CXX` environment variable to the path to your C++ compiler)",
+            default_cpp_compiler.path()
+        );
+        let Ok(path_to_clang) = which("clang++") else {
+            println!("cargo::error=Could not find `clang++` on the system");
+            return None;
+        };
+        println!("cargo::warning=Using {:?} as a C++ compiler", path_to_clang);
+        cpp_build_config.compiler(path_to_clang);
+    }
+    Some(cpp_build_config)
+}
+
+fn build_wasi_sdk(wasi_sdk_path: &dyn AsRef<Path>) -> PathBuf {
+    let wasi_sdk_path = wasi_sdk_path.as_ref();
+
+    // Call the two functions together, so that all of their warnings/errors are emitted, even if one of them fails.
+    let (Some(c_compiler_cfg), Some(cpp_compiler_cfg)) =
+        (wasi_c_compiler_cfg(), wasi_cpp_compiler_cfg())
+    else {
+        // Error messages were printed by `wasi_{c,cpp}_compiler`
+        std::process::exit(1);
+    };
+
+    let mut cmake_config = CMakeConfig::new(wasi_sdk_path);
+    let wasi_build_dir =
+        PathBuf::from(env::var("OUT_DIR").expect("cargo shall set OUT_DIR"))
+            .join("wasi_sysroot");
+    cmake_config.out_dir(wasi_build_dir)
+        .target(&env::var("HOST").expect("cargo shall set HOST"))
+        .no_default_flags(true) // We are in a cross-compiling environment but this build is for the host
+        .init_c_cfg(c_compiler_cfg)
+        .init_cxx_cfg(cpp_compiler_cfg)
+        .define("WASI_SDK_EXCEPTIONS", "ON")
+        .define("WASI_SDK_INCLUDE_TESTS", "OFF")
+        .profile(match env::var("PROFILE").expect("PROFILE is not set").as_str() {
+            "debug" => "Debug",
+            "release" => "Release",
+            unknown => {
+                println!("cargo::warning=Unknown cargo PROFILE '{unknown}', building as RelWithDebInfo");
+                "RelWithDebInfo"
+            }
+        });
+    cmake_config.build()
+}

--- a/build/windows.rs
+++ b/build/windows.rs
@@ -76,7 +76,7 @@ pub fn configure_libclang() {
 
             // SAFETY: The function is always safe to call on Windows.
             unsafe { env::set_var("LIBCLANG_PATH", &chosen) };
-            println!("cargo:rustc-env=LIBCLANG_PATH={}", chosen.display());
+            println!("cargo::rustc-env=LIBCLANG_PATH={}", chosen.display());
         }
     }
 }

--- a/build/xgrammar_cmake.rs
+++ b/build/xgrammar_cmake.rs
@@ -48,7 +48,10 @@ fn maybe_clear_cmake_build_dir(
     }
 }
 
-pub fn build_xgrammar_cmake(ctx: &BuildContext) -> PathBuf {
+pub fn build_xgrammar_cmake(
+    ctx: &BuildContext,
+    extra_c_cxx_flags: &[&str],
+) -> PathBuf {
     let cmake_build_dir = ctx.out_dir.join("build");
     maybe_clear_cmake_build_dir(&cmake_build_dir, &ctx.xgrammar_src_dir);
     create_dir_all(&cmake_build_dir).ok();
@@ -72,6 +75,11 @@ pub fn build_xgrammar_cmake(ctx: &BuildContext) -> PathBuf {
     cmake_config.define("CMAKE_CXX_EXTENSIONS", "OFF");
 
     cmake_config.define("CMAKE_INTERPROCEDURAL_OPTIMIZATION", "OFF");
+
+    for flag in extra_c_cxx_flags {
+        cmake_config.cflag(flag);
+        cmake_config.cxxflag(flag);
+    }
 
     let is_msvc = ctx.target.contains("msvc");
     if !is_msvc {


### PR DESCRIPTION
This PR adds support for building for wasm32-wasi targets, and makes some other refactoring changes on the way.

Changes are grouped into commits according to their purpose. It should be more convenient to review it commit by commit; you might also want to merge this with a rebase, rather than a squash and rebase, so that changes with unrelated purposes remain in separate commits.

Relates to #8.

A few notes:

- `wasm32-wasip1` and `wasm32-wasip2` are supported, but `wasm32-wasip1-threads` is not due to a compiler bug (rust-lang/rust#131007). Hopefully, we can fix this soon in the upstream (and this will not require a nightly compiler version); otherwise we can work around this with a patch in `cc`.
- The CI now checks cross-compilation to wasm targets from Ubuntu only. It should also be possible from MacOS, but I cannot go through the process locally, and setting it up in GitHub Actions is very inconvenient. I left it as a TODO for now; we can either merge it as-is for now, or someone with a MacOS device can help me out here by contributing the workflow steps to set up the suitable clang compiler in a MacOS build.
- Occasionally the wasi-sdk build fails spuriously :(
  Just rerunning it again fixes it. Seems like there's not much we can do - it's probably an upstream build configuration dependency issue...
- The `tokenizers` feature for now is only supported on wasm when the user provides the toolchain. I hope we can fix that, that will require a change in the huggingface's library that we depend on.