### PR TITLE
Support wasm32-wasip1-threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         # TODO: test wasi builds on MacOS, too
         os: [ubuntu-latest]
         # TODO: add wasm32-wasip1-threads when supported
-        target: [native, wasm32-wasip1, wasm32-wasip2]
+        target: [native, wasm32-wasip1, wasm32-wasip1-threads, wasm32-wasip2]
         include:
           - os: macos-latest
             target: native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         if: matrix.target == 'native'
         run: cargo doc --locked --no-deps --features hf
 
-      - name: Build for ${{ matrix.target }}
+      - name: "Cross-compile for: ${{ matrix.target }}"
         if: matrix.target != 'native'
         run: |
           export RUST_BACKTRACE=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokenizers = { version = "0.22", features = ["fancy-regex"], default-features = 
 serde_json = "1.0"
 
 [build-dependencies]
-cc = "1.2.62"
+cc = "1.2.65"
 cmake = "0.1"
 cxx-build = { version = "1", git = "https://github.com/trymirai/cxx.git", branch = "master" }
 walkdir = "2.5"


### PR DESCRIPTION
Add support for the wasm32-wasip1-threads target by bumping the `cc` version. Actual fixes: rust-lang/rust#157644, rust-lang/cc-rs#1763.

This concludes the series of patches for wasm32 support (#8). @eugenebokhan, after we merge this, we supposedly need another release of xgrammar-rs, to use in uzu. Before creating a new release, you might want to consider #7.